### PR TITLE
Add Dockerfile so we can run the cli in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8
+
+ENV VAMP_CLI_VERSION=0.9.1
+ENV WORKDIR=/opt/vamp
+
+RUN mkdir -p ${WORKDIR} && \
+  wget -nv -O /tmp/vamp-cli.zip https://bintray.com/artifact/download/magnetic-io/downloads/vamp-cli/vamp-cli-${VAMP_CLI_VERSION}.zip && \
+  unzip -d ${WORKDIR} /tmp/vamp-cli.zip
+
+WORKDIR "${WORKDIR}"
+
+ENTRYPOINT ["java", "-jar", "vamp-cli.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  vamp:
+    build: .


### PR DESCRIPTION
This is setup to execute the vamp cli using an ENTRYPOINT.  So there are two ways to use this image:

`docker run [path-to-repo] help` (once its built and pushed somewhere)

Or within the repository by using docker-compose (which will build the image automatically)

`docker-compose run vamp help`